### PR TITLE
fix: table name case in latest migration

### DIFF
--- a/prisma/migrations/20241217082519_edit_note_recommendation_optional/migration.sql
+++ b/prisma/migrations/20241217082519_edit_note_recommendation_optional/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE `servicerecommendationitem` MODIFY `note` VARCHAR(191) NULL;
+ALTER TABLE `ServiceRecommendationItem` MODIFY `note` VARCHAR(191) NULL;


### PR DESCRIPTION
Please pay attention to table name in migration. Because it is case sensitive, it can be the cause of failed applying migration.